### PR TITLE
Add Arm64 Support

### DIFF
--- a/examples/nomad/otel-agent.nomad
+++ b/examples/nomad/otel-agent.nomad
@@ -1,5 +1,5 @@
 variables {
-  otel_image = "otel/opentelemetry-collector:0.38.0"
+  otel_image = "otel/opentelemetry-collector:0.47.0"
 }
 
 job "otel-agent" {

--- a/examples/nomad/otel-collector.nomad
+++ b/examples/nomad/otel-collector.nomad
@@ -1,5 +1,5 @@
 variables {
-  otel_image = "otel/opentelemetry-collector:0.38.0"
+  otel_image = "otel/opentelemetry-collector:0.47.0"
 }
 
 job "otel-collector" {

--- a/examples/nomad/otel-demo.nomad
+++ b/examples/nomad/otel-demo.nomad
@@ -1,5 +1,5 @@
 variables {
-  otel_image = "otel/opentelemetry-collector:0.38.0"
+  otel_image = "otel/opentelemetry-collector:0.47.0"
 }
 
 job "otel-demo" {


### PR DESCRIPTION
Modified otel-collector.nomad, otel-demo.nomad and otel-agent.nomad examples files to modify the ```otel/opentelemetry-collector``` version to **0.43.0** from **0.38.0**. Since version **0.43.0** support both arm64 and amd64 platform.

Related to #4 